### PR TITLE
Fix an import error in StockTradeRecordProcessor.java

### DIFF
--- a/src/com/amazonaws/services/kinesis/samples/stocktrades/processor/StockTradeRecordProcessor.java
+++ b/src/com/amazonaws/services/kinesis/samples/stocktrades/processor/StockTradeRecordProcessor.java
@@ -15,7 +15,7 @@ import com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.ThrottlingException;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason;
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.samples.stocktrades.model.StockTrade;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
It seems that in "StockTradeRecordProcessor.java" file, we use the wrong path to import the "ShutdownReason" class in KCL (version-1). So I have correct the path, it should be in the "lib/worker/" under "clientlibrary" directory instead of "types".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
