### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The master branch provides completed code for the [Process Real-Time Stock Data 
 
 The tutorial uses KCL 2.2.9 to demonstrate how to send a stream of records to Kinesis Data Streams and implement an application that consumes and processes the records in near-real time. 
 
-[learning-kinesis]:  https://docs.aws.amazon.com/streams/latest/dev/tutorial-stock-data-kplkcl.html
+[learning-kinesis]:  https://docs.aws.amazon.com/streams/latest/dev/tutorial-stock-data-kplkcl2.html
 [kinesis-developer-guide]: http://docs.aws.amazon.com/kinesis/latest/dev/introduction.html
 
 ## License Summary


### PR DESCRIPTION
Fix the learning kinesis link to link to the KCL 2.x tutorial

*Issue #, if available:*
None

*Description of changes:*
The link in the README linked to a tutorial using KCL 1.x which contradicted the rest of the README and encouraged the use of older versions of the KCL.

I did verify that if you check out the indicated 2.x version, you will still get 2.2.9.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
